### PR TITLE
Switch to tox for tests and add GitHub actions

### DIFF
--- a/.github/workflows/run_tox.yml
+++ b/.github/workflows/run_tox.yml
@@ -1,13 +1,14 @@
-name: Python package
+name: AAMG CI
 
 on: [push]
 
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python: [3.6, 3.7, 3.8]
 
     steps:

--- a/.github/workflows/run_tox.yml
+++ b/.github/workflows/run_tox.yml
@@ -1,0 +1,22 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.6, 3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install Tox and any other packages
+        run: pip install -r requirements.txt
+      - name: Run Tox
+        run: tox -e py  # Run tox using the version of Python in `PATH`

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+# Include our requirement file
+include requirements.txt
+
+# Include our license
+include LICENSE
+
+# Include all tests
+include tests/*_test.py

--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
 # aamg
 Automatic Astrophysical Model Generator
 
-##  Setup
+## Installation
+
+To install the aamg library and the aamg-gen script run:
+
+```
+    $ python setup.py install
+```
+
+The previous command might need administrative privileges if you are not in a
+virtual environment.
+
+##  Development setup
 
 To fetch all dependencies just use:
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,24 @@
 # aamg
 Automatic Astrophysical Model Generator
 
+##  Setup
+
+To fetch all dependencies just use:
+
+```
+    $ pip install -r requirements.txt
+```
+
+The previous command might need administrative privileges if you are not in a
+virtual environment.
+
 ## Running our tests
 
 If you want to run our tests you can simply clone the repository and run the
 following command:
 
 ```
-    $ python3 setup.py test
+    $ tox
 ```
 
 ## Writing tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 setuptools
+tox

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 with open('README.md', 'r') as f:
     long_description = f.read()
 
-with open('requirements.txt') as f:
+with open('requirements.txt', 'r') as f:
     required = f.read().splitlines()
 
 setuptools.setup(
@@ -16,12 +16,12 @@ setuptools.setup(
     long_description=long_description,
     license="MIT",
 
+    # Environment
+    python_requires='>=3.6',
+
     # Scripts and packages.
     scripts=['bin/aamg-gen'],
     packages=['aamg'],
-
-    # Set our test suite so we can use `python3 setup.py test` to run tests.
-    test_suite='tests.suite.aamg_test_suite',
 
     # Load requirements from file in project root.
     install_requires=required

--- a/tests/suite.py
+++ b/tests/suite.py
@@ -1,8 +1,0 @@
-import unittest
-
-
-def aamg_test_suite():
-    '''This discovers tests automatically for us and is called by `setup.py`'''
-    test_loader = unittest.TestLoader()
-    test_suite = test_loader.discover('tests', pattern='*_test.py')
-    return test_suite

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py>=36
+
+[testenv]
+commands = discover -s tests -p '*_test.py'
+deps = discover


### PR DESCRIPTION
Hey,

I *finally* found the time to drop `setup.py` for our testsuite entrypoint.

We can now just install the requirements and run `tox` to build and test our project.